### PR TITLE
Trying to get CI running on macOS latest.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,9 @@ jobs:
   # Run bita tests.
   bita:
     name: "bita tests"
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         rust:
           - stable
           - nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
   # Run bita tests.
   bita:
     name: "bita tests"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
Not really familiar with GitHub actions, but this should maybe run the `bita tests` job also on macOS latest. This to ensure macOS compatibility does not break again.