### PR TITLE
fix zstd compression level range

### DIFF
--- a/bitar/src/compression.rs
+++ b/bitar/src/compression.rs
@@ -69,7 +69,9 @@ impl CompressionAlgorithm {
             #[cfg(feature = "lzma-compression")]
             CompressionAlgorithm::Lzma => 9,
             #[cfg(feature = "zstd-compression")]
-            CompressionAlgorithm::Zstd => 22,
+            CompressionAlgorithm::Zstd => {
+                u32::try_from(*zstd::compression_level_range().end()).unwrap()
+            }
             CompressionAlgorithm::Brotli => 11,
         }
     }


### PR DESCRIPTION
Fixes #54.

When using zstd compression the valid compression range should be 1 - 22 but bita incorrectly limited to 21. This PR should fix this.

